### PR TITLE
Start simulation from mail, fix #4

### DIFF
--- a/django_leeway/core/settings.py
+++ b/django_leeway/core/settings.py
@@ -134,6 +134,9 @@ CELERY_TASK_TIME_LIMIT = 30 * 60
 CELERY_BROKER_URL = 'redis://localhost:6379/0'
 CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
 
-SIMULATION_PATH=os.path.join(BASE_DIR.parent, "simulation")
+SIMULATION_PATH = os.path.join(BASE_DIR.parent, "simulation")
 
-MAIL_FROM="noreply@example.com"
+MAIL_USER = "user@example.com"
+MAIL_PASS = "MYSECERET"
+MAIL_SMTP = "smtp.example.com" # uses StartTLS on port 587
+MAIL_IMAP = "imap.example.com" # uses SSL on Port 993

--- a/django_leeway/leeway/celery.py
+++ b/django_leeway/leeway/celery.py
@@ -1,22 +1,38 @@
+"""
+Configure Celery workers
+"""
 import os
-
+from imaplib import IMAP4_SSL
+import email
 from celery import Celery
+from django.conf import settings
 
-# Set the default Django settings module for the 'celery' program.
+from .utils import mail_to_simulation
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
-
-app = Celery('leeway')
-
-# Using a string here means the worker doesn't have to serialize
-# the configuration object to child processes.
-# - namespace='CELERY' means all celery-related configuration keys
-#   should have a `CELERY_` prefix.
+app = Celery('leeway')  # pylint: disable=invalid-name
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
-# Load task modules from all registered Django apps.
+@app.on_after_configure.connect
+def setup_periodic_tasks(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    Set up periodic tasks, i.e. retrieving mails from the mailbox
+    """
+    sender.add_periodic_task(60, check_mailbox.s(), name='check_mailbox')
+
+@app.task
+def check_mailbox():
+    """
+    Fetch mails from mailbox via IMAP and create new jobs
+    """
+    mailbox = IMAP4_SSL(host=settings.MAIL_IMAP)
+    mailbox.login(settings.MAIL_USER, settings.MAIL_PASS)
+    mailbox.select('Inbox')
+    typ, data = mailbox.search(None, 'UNSEEN')  # pylint: disable=unused-variable
+    for num in data[0].split():
+        typ, data = mailbox.fetch(num, '(RFC822)')
+        mail_to_simulation(email.message_from_bytes(data[0][1]))
+    mailbox.close()
+    mailbox.logout()
+
 app.autodiscover_tasks()
-
-
-@app.task(bind=True)
-def debug_task(self):
-    print(f'Request: {self.request!r}')

--- a/django_leeway/leeway/tasks.py
+++ b/django_leeway/leeway/tasks.py
@@ -1,16 +1,21 @@
-import subprocess, sys
-
+import subprocess
+import sys
 from datetime import datetime
+from imaplib import IMAP4_SSL
 
 from django.conf import settings
-
-from .celery import app
-from .utils import send_result_mail
 from celery import shared_task
 from leeway.models import LeewaySimulation
 
+from .celery import app
+from .utils import send_result_mail
+
 @app.task
 def run_leeway_simulation(request_id):
+    """
+    Get parameters for simulation from database and kick off the simulation
+    process in a docker container. The result is then mailed to the user.
+    """
     simulation = LeewaySimulation.objects.get(uuid=request_id)
     simulation.simulation_started = datetime.now()
     simulation.save()

--- a/example-config/leeway-celery@.service
+++ b/example-config/leeway-celery@.service
@@ -7,7 +7,7 @@ After=syslog.target network.target
 Type=simple
 User=www-data
 WorkingDirectory=/opt/leeway/django_leeway
-ExecStart=/opt/leeway/.venv/bin/celery -A leeway worker -l INFO  --concurrency=%I
+ExecStart=/opt/leeway/.venv/bin/celery -A leeway worker -l INFO -B --concurrency=%I
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
Starts simulations from incoming mails.

The following attributes can be put into a mail subject and/or mail text body:
* `latitude`
* `longitude`
* `duration`
* ` radius`
* `object_type`
* `start_time`

Fixes #4