### PR TITLE
Add GitHub action for automatic releases on PyPI

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,17 @@
+name: Deployment
+on: [push, pull_request]
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Install dependencies
+        run: pip install build twine
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Sample output from the leeway tool (100 points, 1km radius, south of Lampedusa):
       ```
 
 
-# Packaging
+# Releasing
 
-1. Install build dependencies: `python3 -m pip install --upgrade build twine`
-2. Build python package: `python3 -m build`
-3. Upload target distribution to PyPI: `twine upload ./dist/opendrift-leeway-*.tar.gz`
+1. Bump the version in `pyproject.toml`
+2. Commit and push your changes: `git commit -m "Bump version to <version>" && git push`
+3. Tag your commit and push: `git tag <version> && git push origin <version>`
 
 
 # Production Server


### PR DESCRIPTION
This adds a new PyPI release each time a git tag is pushed.