### PR TITLE
Show and clean past simulations, export result, color code trajectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 simulation/output/*.png
+simulation/output/*.nc
 simulation/input/*.nc
 .netrc
 

--- a/opendrift_leeway_webgui/core/settings.py
+++ b/opendrift_leeway_webgui/core/settings.py
@@ -163,6 +163,8 @@ SIMULATION_ROOT = os.environ.get(
     "LEEWAY_SIMULATION_ROOT", os.path.join(BASE_DIR.parent, "simulation")
 )
 
+#: Number of days for keeping simulations and results.
+SIMULATION_RETENTION = int(os.environ.get("LEEWAY_SIMULATION_RETENTION", 7))
 
 ##########
 # CELERY #

--- a/opendrift_leeway_webgui/leeway/templates/base.html
+++ b/opendrift_leeway_webgui/leeway/templates/base.html
@@ -23,7 +23,7 @@
     {% endif %}
     {% block content %}
     {% endblock %}
+    <p><a href="https://github.com/digitalfabrik/leeway">Source Code</a>{% if user.is_authenticated %} | <a href="/simulations/list">List of simulations</a> | <a href="/">New Simulation</a> | <a href="/accounts/logout/">Logout</a>{% endif %}</p>
   </main>
-{% if user.is_authenticated %}<a href="/accounts/logout/">Logout</a>{% endif %}
 </body>
 </html>

--- a/opendrift_leeway_webgui/leeway/templates/simulation-form.html
+++ b/opendrift_leeway_webgui/leeway/templates/simulation-form.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<h2>Leeway Simulation</h2>
+<h2>New Leeway Simulation</h2>
 <p>Please note that only simulations +/- 5 days from now are possible.</p>
 <form method="post">
   <table>

--- a/opendrift_leeway_webgui/leeway/templates/simulations-list.html
+++ b/opendrift_leeway_webgui/leeway/templates/simulations-list.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>List of Leeway Simulations</h2>
+<table border=0>
+  <tr>
+    <th>ID</th>
+    <th>Longitude</th>
+    <th>Latitude</th>
+    <th>Start Time</th>
+    <th>Duration</th>
+    <th>Radius</th>
+    <th>Result</th>
+  </tr>
+{% for simulation in simulations %}
+  <tr>
+    <td>{{ simulation.uuid }}</td>
+    <td>{{ simulation.longitude }}</td>
+    <td>{{ simulation.latitude }}</td>
+    <td>{{ simulation.start_time }}</td>
+    <td>{{ simulation.duration }}</td>
+    <td>{{ simulation.radius}}</td>
+    <td><a href="/media/output/{{ simulation.uuid }}.png">Image</a> <a href="/media/output/{{ simulation.uuid }}.nc">NetCDF</a></td>
+  </tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/opendrift_leeway_webgui/leeway/urls.py
+++ b/opendrift_leeway_webgui/leeway/urls.py
@@ -5,4 +5,5 @@ from . import views
 
 urlpatterns = [
     path('', views.simulation_form, name='home'), # new
+    path('simulations/list/', views.simulations_list, name='simulations_list')
 ]

--- a/opendrift_leeway_webgui/leeway/views.py
+++ b/opendrift_leeway_webgui/leeway/views.py
@@ -2,11 +2,15 @@ from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 
+from .models import LeewaySimulation
 from .forms import LeewaySimulationForm
 from .tasks import run_leeway_simulation
 
 @login_required
 def simulation_form(request):
+    """
+    Form to start new simulation
+    """
     if request.method == "POST":
         lwform = LeewaySimulationForm(
             request.POST
@@ -14,12 +18,24 @@ def simulation_form(request):
         lwform.instance.user = request.user
         if lwform.is_valid():
             lwform.save()
-            messages.add_message(request, messages.INFO,
-                'Request saved. You will receive an e-mail to {} when the simulation is finished. Your request ID is {}.'.format(
-                    request.user.email, lwform.instance.uuid
-                )
+            messages.add_message(
+                request,
+                messages.INFO,
+                ('Request saved. You will receive an e-mail to {} when the simulation is finished. '
+                 'Your request ID is {}.').format(
+                     request.user.email, lwform.instance.uuid
+                 )
             )
             run_leeway_simulation.apply_async([lwform.instance.uuid])
 
     context = {'form': LeewaySimulationForm()}
-    return render(request, context=context, template_name="leeway-simulation.html")
+    return render(request, context=context, template_name="simulation-form.html")
+
+@login_required
+def simulations_list(request):
+    """
+    List all existing simulations of a user
+    """
+    return render(request,
+                  context={'simulations': LeewaySimulation.objects.filter(user=request.user)},
+                  template_name="simulations-list.html")

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -73,7 +73,7 @@ print("Using sources:\n - {}".format("\n - ".join(SOURCES)))
 SIMULATION.add_readers_from_list(SOURCES,
                                  lazy=True)
 
-READER_LANDMASK = reader_global_landmask.Reader(extent=[0, 0, 360, 90])
+READER_LANDMASK = reader_global_landmask.Reader()
 SIMULATION.add_reader([READER_LANDMASK])
 
 SIMULATION.seed_elements(lon=ARGS.longitude,
@@ -82,8 +82,13 @@ SIMULATION.seed_elements(lon=ARGS.longitude,
                          number=ARGS.number, radius=ARGS.radius,
                          object_type=ARGS.object_type)
 
-SIMULATION.run(duration=timedelta(hours=ARGS.duration), time_step=600)
-
 OUTFILE = os.path.join("/code", "leeway", "output", ARGS.id)
-SIMULATION.plot(fast=True, legend=True, filename=OUTFILE)
+
+SIMULATION.run(duration=timedelta(hours=ARGS.duration),
+               time_step=600,
+               outfile="{}.nc".format(OUTFILE)
+              )
+SIMULATION.plot(fast=True, legend=True,
+                filename="{}.png".format(OUTFILE),
+                linecolor='age_seconds')
 print("{}.png written.".format(OUTFILE))


### PR DESCRIPTION
* Add a view for past simulations, fix #45 & fix #44 
* Clean old simulations, fix #49
* Support southern hemisphere, fix #23
* Add raw result, fix #48
* Fix Celery config, fix #52 
* Color code trajectories with simulation age 
  ![image](https://user-images.githubusercontent.com/15197000/206920744-c6fbba9b-4ed8-4c6f-a841-034574fc6f2f.png)
