### PR TITLE
Use `DEFAULT_FROM_EMAIL` when sending mails

### DIFF
--- a/opendrift_leeway_webgui/core/settings.py
+++ b/opendrift_leeway_webgui/core/settings.py
@@ -11,6 +11,8 @@ import os
 from distutils.util import strtobool
 from pathlib import Path
 
+from django.core.exceptions import ImproperlyConfigured
+
 
 ###################
 # CUSTOM SETTINGS #
@@ -214,6 +216,11 @@ EMAIL_HOST = os.environ.get("LEEWAY_EMAIL_HOST", "localhost")
 #: Password to use for the SMTP server defined in :attr:`~LEEWAY.core.settings.EMAIL_HOST`
 #: (see :setting:`django:EMAIL_HOST_PASSWORD`). If empty, Django won’t attempt authentication.
 EMAIL_HOST_PASSWORD = os.environ.get("LEEWAY_EMAIL_HOST_PASSWORD")
+
+if EMAIL_HOST_PASSWORD and not SERVER_EMAIL:
+    raise ImproperlyConfigured(
+        "You have set an `EMAIL_HOST_PASSWORD`, but `SERVER_EMAIL` is missing."
+    )
 
 #: Username to use for the SMTP server defined in :attr:`~LEEWAY.core.settings.EMAIL_HOST`
 #: (see :setting:`django:EMAIL_HOST_USER`). If empty, Django won’t attempt authentication.

--- a/opendrift_leeway_webgui/leeway/utils.py
+++ b/opendrift_leeway_webgui/leeway/utils.py
@@ -102,7 +102,7 @@ def send_confirmation_mail(simulation):
         'Leeway Drift Simulation Order received',
         f'Request saved. You will receive an e-mail to {simulation.user.email} '
         f'when the simulation is finished. Your request ID is {simulation.uuid}.',
-        settings.EMAIL_HOST_USER,
+        None,
         [simulation.user.email],
     )
 
@@ -121,7 +121,6 @@ def send_result_mail(simulation):
     email = EmailMessage(
         subject='Leeway Drift Simulation Result',
         body=mail_result_text(simulation, success),
-        from_email=settings.EMAIL_HOST_USER,
         to=[simulation.user.email]
     )
     # Attach result image


### PR DESCRIPTION
The `EMAIL_HOST_USER` is the username when logging into the SMTP server and is not necessarily an email address.

The [docs](https://docs.djangoproject.com/en/4.1/topics/email/#django.core.mail.EmailMessage) say:

> from_email: The sender’s address. Both fred@example.com and "Fred" <fred@example.com> forms are legal. If omitted, the [DEFAULT_FROM_EMAIL](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-DEFAULT_FROM_EMAIL) setting is used.

And this value is set to `SERVER_EMAIL` in the settings file:
https://github.com/digitalfabrik/leeway/blob/b8858246a469f7cde8571ed65ced7946e67ee04f/opendrift_leeway_webgui/core/settings.py#L209