### PR TITLE
Serve simulations in debug mode

### DIFF
--- a/example-config/apache2.conf
+++ b/example-config/apache2.conf
@@ -25,7 +25,7 @@
   WSGIScriptAlias / /opt/opendrift-leeway-webgui/wsgi.py
 
   Alias /static/ /var/www/opendrift-leeway-webgui/static/
-  Alias /media/ /var/www/opendrift-leeway-webgui/media/
+  Alias /simulations/ /var/www/opendrift-leeway-webgui/simulation/output/
   Alias /robots.txt /srv/robots.txt
 
   <Directory /srv>

--- a/opendrift_leeway_webgui/core/settings.py
+++ b/opendrift_leeway_webgui/core/settings.py
@@ -158,6 +158,9 @@ STATIC_URL = "/static/"
 #: In debug mode, this is not required since :mod:`django.contrib.staticfiles` can directly serve these files.
 STATIC_ROOT = os.environ.get("LEEWAY_STATIC_ROOT")
 
+#: URL where simulations are served
+SIMULATION_URL = "/simulations/"
+
 #: The path where simulation results are stored
 SIMULATION_ROOT = os.environ.get(
     "LEEWAY_SIMULATION_ROOT", os.path.join(BASE_DIR.parent, "simulation")

--- a/opendrift_leeway_webgui/leeway/templates/simulations-list.html
+++ b/opendrift_leeway_webgui/leeway/templates/simulations-list.html
@@ -19,7 +19,7 @@
     <td>{{ simulation.start_time }}</td>
     <td>{{ simulation.duration }}</td>
     <td>{{ simulation.radius}}</td>
-    <td><a href="/media/output/{{ simulation.uuid }}.png">Image</a> <a href="/media/output/{{ simulation.uuid }}.nc">NetCDF</a></td>
+    <td><a href="{{ SIMULATION_URL }}{{ simulation.uuid }}.png">Image</a> <a href="{{ SIMULATION_URL }}{{ simulation.uuid }}.nc">NetCDF</a></td>
   </tr>
 {% endfor %}
 </table>

--- a/opendrift_leeway_webgui/leeway/urls.py
+++ b/opendrift_leeway_webgui/leeway/urls.py
@@ -1,4 +1,6 @@
-from django.urls import path
+from django.conf import settings
+from django.conf.urls.static import static
+from django.urls import include, path
 from django.views.generic.base import TemplateView
 
 from . import views
@@ -7,3 +9,17 @@ urlpatterns = [
     path('', views.simulation_form, name='home'), # new
     path('simulations/list/', views.simulations_list, name='simulations_list')
 ]
+
+# Serve simulation files in debug mode
+if settings.DEBUG:
+    urlpatterns += [
+        path(
+            "",
+            include(
+                (
+                    static(settings.SIMULATION_URL, document_root=settings.SIMULATION_OUTPUT),
+                    "simulation_files",
+                )
+            ),
+        ),
+    ]

--- a/opendrift_leeway_webgui/leeway/views.py
+++ b/opendrift_leeway_webgui/leeway/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
@@ -36,6 +37,11 @@ def simulations_list(request):
     """
     List all existing simulations of a user
     """
-    return render(request,
-                  context={'simulations': LeewaySimulation.objects.filter(user=request.user)},
-                  template_name="simulations-list.html")
+    return render(
+        request,
+        context={
+            "SIMULATION_URL": settings.SIMULATION_URL,
+            "simulations": LeewaySimulation.objects.filter(user=request.user),
+        },
+        template_name="simulations-list.html"
+    )


### PR DESCRIPTION
- Add new setting `SIMULATION_URL` which contains the URL where the simulations are served
- Only serve output directory
- Adapt template and example apache config